### PR TITLE
upgrade go to 1.21.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.55.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
 
       - name: Run tests
         env:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ and a Destination Amazon Redshift connectors.
 
 ## Prerequisites
 
-- [Go](https://go.dev/) 1.20
-- (optional) [golangci-lint](https://github.com/golangci/golangci-lint) 1.51.2
+- [Go](https://go.dev/) 1.21
+- (optional) [golangci-lint](https://github.com/golangci/golangci-lint) 1.55.2
 
 ## How to build it
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/conduitio-labs/conduit-connector-redshift
 
 go 1.21
 
+toolchain go1.21.1
+
 require (
 	github.com/conduitio/conduit-connector-sdk v0.8.0
 	github.com/go-playground/validator/v10 v10.16.0


### PR DESCRIPTION
### Description

Upgrades Go version to 1.21.0 and updates GH actions to use go.mod instead of a hard-coded Go version.

Fixes #998

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-databricks/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.